### PR TITLE
Fix `NameError` by importing `psutil` in `utility.py`

### DIFF
--- a/bigstream/utility.py
+++ b/bigstream/utility.py
@@ -5,7 +5,7 @@ import zarr
 from zarr.indexing import BasicIndexer
 from distributed import Lock
 import glob
-import os
+import os , psutil
 import h5py
 from ClusterWrap.decorator import cluster
 from zarr import blosc


### PR DESCRIPTION
## Description

This PR addresses the `NameError` encountered when using the `get_number_of_cores` function in the `utility.py` module of the `bigstream` package. The root cause was the absence of an import statement for the `psutil` module.

## Changes

- Imported `psutil` in `utility.py` to resolve the `NameError`.

## Testing

After adding the import statement, I tested the function that was previously raising the error, and it now executes without any issues.

Resolves: issue #28 

Please review and let me know if any additional changes are required. Thank you!