### PR TITLE
pass in the step parameter to block's invert_displacement_vector_field

### DIFF
--- a/bigstream/distributed_transform.py
+++ b/bigstream/distributed_transform.py
@@ -538,6 +538,7 @@ def distributed_invert_displacement_vector_field(
         spacing=spacing,
         blocksize=blocksize_array,
         blockoverlaps=overlap,
+        step=step,
         iterations=iterations,
         sqrt_order=sqrt_order,
         sqrt_step=sqrt_step,


### PR DESCRIPTION
Simple fix to simply pass in the step parameter to the block's invert_displacement_vector_field call.