### PR TITLE
Restored verbose=True behavior in inverse/root functions in transform but with logging instead of print

### DIFF
--- a/bigstream/transform.py
+++ b/bigstream/transform.py
@@ -531,7 +531,6 @@ def invert_displacement_vector_field(
         if add_handler:
             logger.addHandler(logging.StreamHandler(stream=sys.stdout))
         logger.setLevel(logging.DEBUG)
-        print(logger.handlers)
 
     # initialize inverse as negative root
     root = field
@@ -726,7 +725,6 @@ def displacement_field_composition_square_root(
         if add_handler:
             logger.addHandler(logging.StreamHandler(stream=sys.stdout))
         logger.setLevel(logging.DEBUG)
-        print(logger.handlers)
 
     # pad input
     if pad > 0:

--- a/bigstream/transform.py
+++ b/bigstream/transform.py
@@ -4,6 +4,7 @@ import SimpleITK as sitk
 import bigstream.utility as ut
 from bigstream.configure_irm import interpolator_switch
 import os
+import sys
 from scipy.ndimage import map_coordinates, zoom, gaussian_filter
 
 
@@ -521,6 +522,17 @@ def invert_displacement_vector_field(
         inverse_field(field) should be nearly zeros everywhere.
     """
 
+    # set logger status
+    if verbose:
+        add_handler = True
+        for handler in logger.handlers:
+            if isinstance(handler, logging.StreamHandler) and handler.stream == sys.stdout:
+                add_handler = False; break
+        if add_handler:
+            logger.addHandler(logging.StreamHandler(stream=sys.stdout))
+        logger.setLevel(logging.DEBUG)
+        print(logger.handlers)
+
     # initialize inverse as negative root
     root = field
     if use_root:
@@ -705,6 +717,17 @@ def displacement_field_composition_square_root(
         compose_displacement_vector_fields(root, root, spacing, spacing) ~= field
     """
 
+    # set logger status
+    if verbose:
+        add_handler = True
+        for handler in logger.handlers:
+            if isinstance(handler, logging.StreamHandler) and handler.stream == sys.stdout:
+                add_handler = False; break
+        if add_handler:
+            logger.addHandler(logging.StreamHandler(stream=sys.stdout))
+        logger.setLevel(logging.DEBUG)
+        print(logger.handlers)
+
     # pad input
     if pad > 0:
         pad = tuple(round(pad*x) for x in field.shape[:-1])
@@ -715,7 +738,7 @@ def displacement_field_composition_square_root(
     field_smooth_store = {}
 
     # loop over scale levels
-    level_values = zip(iterations, shrink_spacings, smooth_sigmas)
+    level_values = tuple(zip(iterations, shrink_spacings, smooth_sigmas))
     logger.info(f'Displacement vector leveled iterations: {level_values}')
 
     for level, (iterations_level, shrink, sigma) in enumerate(level_values):


### PR DESCRIPTION
Checks handlers list of module level handler for existing stdout StreamHandler, if not present, adds it. Sets logging level to DEBUG.

More of a patch sized change. Perhaps now that I've had a closer look we can come up with an overall logging system that is more flexible, allowing some modules to have different streams and levels for example. This should eventually be controlled at the package level with functions like your `configure_logging`

@cgoina 